### PR TITLE
Make file download fail-safe and retry on transient errors

### DIFF
--- a/src/main/java/io/simplelocalize/cli/client/SimpleLocalizeClient.java
+++ b/src/main/java/io/simplelocalize/cli/client/SimpleLocalizeClient.java
@@ -35,6 +35,8 @@ public class SimpleLocalizeClient
 {
 
   private static final String ERROR_MESSAGE_PATH = "$.msg";
+  private static final int MAX_DOWNLOAD_ATTEMPTS = 3;
+  private static final long RETRY_DELAY_MILLIS = 1000;
   private final HttpClient httpClient;
   private final SimpleLocalizeHttpRequestFactory httpRequestFactory;
   private final SimpleLocalizeUriFactory uriFactory;
@@ -129,8 +131,58 @@ public class SimpleLocalizeClient
       Files.createDirectories(parentDirectory);
     }
     log.info("Downloading {}", savePath);
-    HttpResponse<Path> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofFile(savePath, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING));
-    throwOnError(response);
+    for (int attempt = 1; ; attempt++)
+    {
+      HttpResponse<Path> response;
+      try
+      {
+        response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofFile(savePath, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING));
+      } catch (IOException e)
+      {
+        if (attempt >= MAX_DOWNLOAD_ATTEMPTS)
+        {
+          throw e;
+        }
+        log.warn("Downloading {} failed: {}, retrying ({}/{})", savePath, e.getMessage(), attempt + 1, MAX_DOWNLOAD_ATTEMPTS);
+        Thread.sleep(RETRY_DELAY_MILLIS * attempt);
+        continue;
+      }
+      if (response.statusCode() == 200)
+      {
+        return;
+      }
+      // the body handler wrote the error response to savePath; don't leave it there as a translation file
+      try
+      {
+        if (isRetryableStatusCode(response.statusCode()) && attempt < MAX_DOWNLOAD_ATTEMPTS)
+        {
+          log.warn("Downloading {} failed with HTTP {}, retrying ({}/{})", savePath, response.statusCode(), attempt + 1, MAX_DOWNLOAD_ATTEMPTS);
+        } else
+        {
+          throwOnError(response);
+        }
+      } finally
+      {
+        deleteQuietly(savePath);
+      }
+      Thread.sleep(RETRY_DELAY_MILLIS * attempt);
+    }
+  }
+
+  private boolean isRetryableStatusCode(int statusCode)
+  {
+    return statusCode == 429 || statusCode >= 500;
+  }
+
+  private void deleteQuietly(Path path)
+  {
+    try
+    {
+      Files.deleteIfExists(path);
+    } catch (IOException e)
+    {
+      log.warn("Unable to remove incomplete file: {}", path);
+    }
   }
 
   public String fetchProject() throws IOException, InterruptedException
@@ -192,19 +244,34 @@ public class SimpleLocalizeClient
   {
     if (httpResponse.statusCode() != 200)
     {
-      com.jayway.jsonpath.Configuration parseContext = com.jayway.jsonpath.Configuration
-              .defaultConfiguration()
-              .addOptions(Option.SUPPRESS_EXCEPTIONS);
-
-      Object responseBody = httpResponse.body();
-      String stringBody = safeCastHttpBodyToString(responseBody);
-      String message = JsonPath.using(parseContext).parse(stringBody).read(ERROR_MESSAGE_PATH);
-      if (message == null)
+      String message = tryReadErrorMessage(httpResponse);
+      if (StringUtils.isBlank(message))
       {
         message = "Unknown error, HTTP Status: " + httpResponse.statusCode();
       }
       log.error("Request failed: {}", message);
       throw new ApiRequestException(message);
+    }
+  }
+
+  private String tryReadErrorMessage(HttpResponse<?> httpResponse)
+  {
+    String stringBody = safeCastHttpBodyToString(httpResponse.body());
+    if (StringUtils.isBlank(stringBody))
+    {
+      return null;
+    }
+    try
+    {
+      com.jayway.jsonpath.Configuration parseContext = com.jayway.jsonpath.Configuration
+              .defaultConfiguration()
+              .addOptions(Option.SUPPRESS_EXCEPTIONS);
+      Object message = JsonPath.using(parseContext).parse(stringBody).read(ERROR_MESSAGE_PATH);
+      return message != null ? String.valueOf(message) : null;
+    } catch (Exception e)
+    {
+      log.debug("Unable to extract error message from response body", e);
+      return null;
     }
   }
 
@@ -216,6 +283,15 @@ public class SimpleLocalizeClient
     } else if (responseBody instanceof String responseBodyString)
     {
       return responseBodyString;
+    } else if (responseBody instanceof Path responseBodyPath)
+    {
+      try
+      {
+        return Files.readString(responseBodyPath);
+      } catch (IOException e)
+      {
+        return "";
+      }
     }
     return "";
   }

--- a/src/test/java/io/simplelocalize/cli/client/SimpleLocalizeClientTest.java
+++ b/src/test/java/io/simplelocalize/cli/client/SimpleLocalizeClientTest.java
@@ -272,4 +272,120 @@ public class SimpleLocalizeClientTest
     //then
     assertThat(Path.of(downloadPath)).hasContent("sample").isRegularFile();
   }
+
+  @Test
+  void shouldThrowApiRequestExceptionWhenDownloadFailsWithEmptyBody()
+  {
+    //given
+    SimpleLocalizeClient client = new SimpleLocalizeClient(MOCK_SERVER_BASE_URL, "96a7b6ca75c79d4af4dfd5db2946fdd4");
+    mockServer.when(request()
+                            .withMethod("GET")
+                            .withPath("/s3/missing-file"),
+                    Times.exactly(1))
+            .respond(
+                    response()
+                            .withStatusCode(403)
+                            .withDelay(TimeUnit.MILLISECONDS, 200)
+            );
+
+    DownloadableFile downloadableFile = new DownloadableFile(MOCK_SERVER_BASE_URL + "/s3/missing-file", "common", null, null, null, null);
+    String downloadPath = "./junit/download-error/file.json";
+
+    //when & then
+    Assertions
+            .assertThatThrownBy(() -> client.downloadFile(downloadableFile, downloadPath))
+            .isInstanceOf(ApiRequestException.class)
+            .hasMessage("Unknown error, HTTP Status: 403");
+
+    assertThat(Path.of(downloadPath)).doesNotExist();
+  }
+
+  @Test
+  void shouldThrowApiRequestExceptionWithMessageWhenDownloadFailsWithJsonBody()
+  {
+    //given
+    SimpleLocalizeClient client = new SimpleLocalizeClient(MOCK_SERVER_BASE_URL, "96a7b6ca75c79d4af4dfd5db2946fdd4");
+    mockServer.when(request()
+                            .withMethod("GET")
+                            .withPath("/s3/expired-file"),
+                    Times.exactly(1))
+            .respond(
+                    response()
+                            .withStatusCode(410)
+                            .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                            .withBody("{ \"msg\": \"link expired\" }")
+                            .withDelay(TimeUnit.MILLISECONDS, 200)
+            );
+
+    DownloadableFile downloadableFile = new DownloadableFile(MOCK_SERVER_BASE_URL + "/s3/expired-file", "common", null, null, null, null);
+    String downloadPath = "./junit/download-error/expired.json";
+
+    //when & then
+    Assertions
+            .assertThatThrownBy(() -> client.downloadFile(downloadableFile, downloadPath))
+            .isInstanceOf(ApiRequestException.class)
+            .hasMessage("link expired");
+
+    assertThat(Path.of(downloadPath)).doesNotExist();
+  }
+
+  @Test
+  void shouldRetryDownloadOnServerError() throws Exception
+  {
+    //given
+    SimpleLocalizeClient client = new SimpleLocalizeClient(MOCK_SERVER_BASE_URL, "96a7b6ca75c79d4af4dfd5db2946fdd4");
+    mockServer.when(request()
+                            .withMethod("GET")
+                            .withPath("/s3/flaky-file"),
+                    Times.exactly(2))
+            .respond(
+                    response()
+                            .withStatusCode(500)
+            );
+    mockServer.when(request()
+                            .withMethod("GET")
+                            .withPath("/s3/flaky-file"),
+                    Times.exactly(1))
+            .respond(
+                    response()
+                            .withStatusCode(200)
+                            .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                            .withBody("{ \"key\": \"value\" }")
+            );
+
+    DownloadableFile downloadableFile = new DownloadableFile(MOCK_SERVER_BASE_URL + "/s3/flaky-file", "common", null, null, null, null);
+    String downloadPath = "./junit/download-retry/file.json";
+
+    //when
+    client.downloadFile(downloadableFile, downloadPath);
+
+    //then
+    assertThat(Path.of(downloadPath)).hasContent("{ \"key\": \"value\" }").isRegularFile();
+  }
+
+  @Test
+  void shouldGiveUpDownloadAfterMaxRetryAttempts()
+  {
+    //given
+    SimpleLocalizeClient client = new SimpleLocalizeClient(MOCK_SERVER_BASE_URL, "96a7b6ca75c79d4af4dfd5db2946fdd4");
+    mockServer.when(request()
+                            .withMethod("GET")
+                            .withPath("/s3/broken-file"),
+                    Times.exactly(3))
+            .respond(
+                    response()
+                            .withStatusCode(503)
+            );
+
+    DownloadableFile downloadableFile = new DownloadableFile(MOCK_SERVER_BASE_URL + "/s3/broken-file", "common", null, null, null, null);
+    String downloadPath = "./junit/download-retry/broken.json";
+
+    //when & then
+    Assertions
+            .assertThatThrownBy(() -> client.downloadFile(downloadableFile, downloadPath))
+            .isInstanceOf(ApiRequestException.class)
+            .hasMessage("Unknown error, HTTP Status: 503");
+
+    assertThat(Path.of(downloadPath)).doesNotExist();
+  }
 }


### PR DESCRIPTION
## What

Fixes a crash when a translation file download fails, and adds bounded retry for transient download errors.

## Why

A failed download (e.g. an expired or forbidden S3 link) crashed the CLI with an unhelpful stack trace instead of a proper error message:

```
java.lang.IllegalArgumentException: json string can not be null or empty
	at com.jayway.jsonpath.internal.Utils.notEmpty(Utils.java:401)
	at com.jayway.jsonpath.internal.ParseContextImpl.parse(ParseContextImpl.java:36)
	at io.simplelocalize.cli.client.SimpleLocalizeClient.throwOnError(SimpleLocalizeClient.java:201)
	at io.simplelocalize.cli.client.SimpleLocalizeClient.downloadFile(SimpleLocalizeClient.java:133)
	...
```

Root cause: for file downloads the response body is a `Path` (from `BodyHandlers.ofFile`), which `safeCastHttpBodyToString` turned into `""`, and `JsonPath.parse("")` throws before `SUPPRESS_EXCEPTIONS` can apply. The same crash affected any endpoint returning an error with an empty body.

## Changes

- **`throwOnError` never crashes on unparseable bodies**: error-message extraction skips blank bodies and catches any JsonPath failure, falling back to `Unknown error, HTTP Status: <code>`.
- **`Path` bodies are read for error messages**: failed downloads now surface the server's actual error message (e.g. `link expired`) instead of a generic one.
- **No error payload left on disk**: `BodyHandlers.ofFile(..., TRUNCATE_EXISTING)` writes the error response to the target translation file on failure; it is now deleted instead of being left behind masquerading as a translation file.
- **Downloads retry on transient errors**: up to 3 attempts with linear backoff (1s, 2s) on `IOException`, HTTP 429, and 5xx. Other 4xx (403/404) fail fast since retrying can't help.

## Notes for reviewers

- Existing behavior for permanent errors is unchanged: an `ApiRequestException` with the extracted (or fallback) message.
- One known pre-existing limitation not addressed here: a failed download still truncates a pre-existing local file before the failure is detected. Downloading to a temp file and moving on success would fix that; happy to do it in a follow-up.

## Tests

Added coverage in `SimpleLocalizeClientTest` (mock-server based):
- download fails with empty body → clean `ApiRequestException`, no leftover file (the reported crash)
- download fails with JSON error body → message extracted from `$.msg`
- server returns 500 twice then 200 → download succeeds on the third attempt with correct content
- server returns 503 three times → gives up after max attempts, no leftover file

Full suite passes: 88 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)